### PR TITLE
fix getting node from initiated template when mixing dom elements with custom elements

### DIFF
--- a/src/dom/element.rs
+++ b/src/dom/element.rs
@@ -442,9 +442,9 @@ where
 
         let mut temp_path = results.id.clone();
         let mut next_placeholder = None;
-        for (index, (child1, child2)) in (mutable_child_nodes.iter_mut())
+        let mut index = 0;
+        for (child1, child2) in (mutable_child_nodes.iter_mut())
             .zip(immutable_child_nodes.iter())
-            .enumerate()
         {
             results.template += &child2.template;
 
@@ -473,6 +473,8 @@ where
                 results.post_exprs.append(&mut child1.post_exprs);
                 results.has_custom_element |= child2.has_custom_element;
                 temp_path = Some(id.clone());
+
+                index += 1;
             } else if !child1.exprs.is_empty() {
                 let insert = self.register_import_method("insert");
                 let multi = filtered_children.len() > 1;
@@ -481,7 +483,9 @@ where
                     let (expr_id, content_id) = if let Some(placeholder) = next_placeholder {
                         (placeholder, None)
                     } else {
-                        create_placeholder(results, &temp_path, index, "")
+                        let placeholder= create_placeholder(results, &temp_path, index, "");
+                        index += 1;
+                        placeholder
                     };
                     next_placeholder = Some(expr_id.clone());
                     results.exprs.push(Expr::Call(CallExpr {

--- a/tests/fixture/mixed-component-element/input.js
+++ b/tests/fixture/mixed-component-element/input.js
@@ -1,0 +1,12 @@
+const A = () => (
+    <div>A</div>
+);
+
+const B = (b) => (
+    <div>
+        <A/>
+        <p class={b}>b</p>
+        <A/>
+        <p className={b}>c</p>
+    </div>
+);

--- a/tests/fixture/mixed-component-element/output.js
+++ b/tests/fixture/mixed-component-element/output.js
@@ -1,0 +1,14 @@
+import { template as _$template } from "r-dom";
+import { insert as _$insert } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+import { className as _$className } from "r-dom";
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>A</div>`, 2), _tmpl$2 = /*#__PURE__*/ _$template(`<div><p>b</p><p>c</p></div>`, 6);
+const A = ()=>_tmpl$.cloneNode(true);
+const B = (b)=>(()=>{
+    const _el$ = _tmpl$2.cloneNode(true), _el$1 = _el$.firstChild, _el$2 = _el$1.nextSibling;
+    _$insert(_el$, _$createComponent(A, {}), _el$1);
+    _$className(_el$1, b);
+    _$insert(_el$, _$createComponent(A, {}), _el$2);
+    _$className(_el$2, b);
+    return _el$;
+})();


### PR DESCRIPTION
don't increase the index used for determining whether to use `firstChild` or `nextSibling` when we don't get a dom node

I'm not a 100% on the logic but it seems to work for now™