### PR TITLE
handle rest of expression type as attribute assign

### DIFF
--- a/src/dom/element.rs
+++ b/src/dom/element.rs
@@ -82,8 +82,6 @@ pub fn set_attr(
 
 #[derive(Debug)]
 enum AttrType<'a> {
-    None,
-    Unsupported(&'a JSXAttrValue),
     Literal(Option<&'a JSXAttrValue>),
     ExprAssign(&'a Expr),
     CallAssign(&'a Expr),
@@ -137,10 +135,8 @@ where
                             Expr::Lit(_) => AttrType::Literal(Some(value)),
                             _ if key.starts_with("ref") => AttrType::Ref(expr),
                             _ if key.starts_with("on") => AttrType::Event(expr),
-                            Expr::Member(_) => AttrType::ExprAssign(expr),
-                            Expr::Ident(_) => AttrType::ExprAssign(expr),
                             Expr::Call(_) => AttrType::CallAssign(expr),
-                            _ => AttrType::Unsupported(value),
+                            _ => AttrType::ExprAssign(expr),
                         },
                     }
                 } else {
@@ -155,8 +151,6 @@ where
             let mut key = aliases.get(key.as_str()).unwrap_or(&key_str);
 
             match value {
-                AttrType::None => {}
-                AttrType::Unsupported(_) => {}
                 AttrType::Event(expr) => {
                     if let Some(event) = key.strip_prefix("on") {
                         let event = event.to_ascii_lowercase();

--- a/tests/fixture/expr-attributes/input.js
+++ b/tests/fixture/expr-attributes/input.js
@@ -3,6 +3,6 @@ const f = () => "a"
 const a = () => {
     let b = f();
     return <div class={f()}>
-        <p title={b}>hi</p>
+        <p title={b + "foo"}>hi</p>
     </div>
 };

--- a/tests/fixture/expr-attributes/output.js
+++ b/tests/fixture/expr-attributes/output.js
@@ -9,7 +9,7 @@ const a = ()=>{
     return (()=>{
         const _el$ = _tmpl$.cloneNode(true), _el$1 = _el$.firstChild;
         _$effect(()=>_$className(_el$, f()));
-        _$setAttribute(_el$1, "title", b);
+        _$setAttribute(_el$1, "title", b + "foo");
         return _el$;
     })();
 };


### PR DESCRIPTION
Probably better to try to assign to my expression types than ignoring ones.