### PR TITLE
fix builtins not always being imported

### DIFF
--- a/src/shared/component.rs
+++ b/src/shared/component.rs
@@ -22,9 +22,7 @@ where
         let has_children = !node.children.is_empty();
 
         if let Expr::Ident(id) = &tag_id {
-            if self.config.built_ins.iter().any(|v| v.as_str() == &id.sym)
-                && id.span.ctxt.as_u32() == 1
-            {
+            if self.config.built_ins.iter().any(|v| v.as_str() == &id.sym) {
                 tag_id = Expr::Ident(self.register_import_method(&id.sym));
             }
         }

--- a/tests/fixture/babel/components/output.js
+++ b/tests/fixture/babel/components/output.js
@@ -4,6 +4,7 @@ import { mergeProps as _$mergeProps } from "r-dom";
 import { memo as _$memo } from "r-dom";
 import { insert as _$insert } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
+import { Show as _$Show } from "r-dom";
 import { For as _$For } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<div>Hello `), _tmpl$2 = /*#__PURE__*/ _$template(`<div>`), _tmpl$3 = /*#__PURE__*/ _$template(`<div>From Parent`), _tmpl$4 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | <!> | <!> | `), _tmpl$5 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | `), _tmpl$6 = /*#__PURE__*/ _$template(`<div> | <!> |  |  | <!> | `), _tmpl$7 = /*#__PURE__*/ _$template(`<span>1`), _tmpl$8 = /*#__PURE__*/ _$template(`<span>2`), _tmpl$9 = /*#__PURE__*/ _$template(`<span>3`);
 import { Show } from "somewhere";
@@ -109,7 +110,7 @@ const template6 = _$createComponent(_$For, {
     get fallback () {
         return _$createComponent(Loading, {});
     },
-    children: (item)=>_$createComponent(Show, {
+    children: (item)=>_$createComponent(_$Show, {
             get when () {
                 return state.condition;
             },


### PR DESCRIPTION
I'm not sure why the imports were limited to only one specific context.

Check was introduced by [this commit](https://github.com/milomg/swc-plugin-jsx-dom-expressions/commit/c24c748cee6c245ddd77f60288bb0c70efc7219d#diff-2e6608821369d72f1a4c4ea5cc1f9d6d1446be2617e1cef466f7528e6429f101)